### PR TITLE
First version

### DIFF
--- a/local-test-operator-bundle.yml
+++ b/local-test-operator-bundle.yml
@@ -26,6 +26,10 @@
         name: install_operator_prereqs
       when: run_prereqs|bool
 
+    - name: "Convert manifest format to bundle when needed"
+      include_role:
+        name: convert_manifest_to_bundle
+
     - name: "Extract the operator bundle image into files needed to run the tests"
       include_role:
         name: extract_operator_bundle

--- a/local-test-operator-bundle.yml
+++ b/local-test-operator-bundle.yml
@@ -20,6 +20,7 @@
         yq_bin_path: "{{ testing_bin_path }}/yq"
         umoci_bin_path: "{{ testing_bin_path }}/umoci"
         opm_bin_path: "{{ testing_bin_path }}/opm"
+        operator_sdk_bin_path: "{{ testing_bin_path }}/operator-sdk"
 
     - name: "Install operator testing prerequisites"
       include_role:

--- a/local.yml
+++ b/local.yml
@@ -10,6 +10,7 @@
     distro_type: "{{ 'upstream' if run_upstream else '' }}"
     work_dir: "/tmp/operator-test"
     operator_dir: "dummy" # so operator-courier will be installed
+    bundle_image: "dummy" # so skopeo and umoci will be installed
     operator_work_dir: "{{ work_dir }}/operator-files"
     testing_bin_path: "{{ work_dir }}/bin"
     oc_bin_path: '{{ ''kubectl'' if run_upstream else "{{ testing_bin_path }}/oc" }}'
@@ -36,4 +37,5 @@
     - { role: install_kind, tags: ["kind"] }
     - { role: install_operator_prereqs, tags: ["operator_prereqs"] }
     - { role: build_catalog_upstream, tags: ["operator_catalog"] }
+    - { role: convert_manifest_to_bundle, tags: ["m2b"] }
     # - { role: operator_courier_verify, tags: ["pure_test", "operator_courier_verify"] }

--- a/roles/convert_manifest_to_bundle/defaults/main.yml
+++ b/roles/convert_manifest_to_bundle/defaults/main.yml
@@ -1,0 +1,2 @@
+operator_manifest_to_bundle_dir: /tmp/operator-test/operator-manifest-to-bundle
+operator_version: latest

--- a/roles/convert_manifest_to_bundle/tasks/main.yml
+++ b/roles/convert_manifest_to_bundle/tasks/main.yml
@@ -1,0 +1,58 @@
+- name: "Ensure that the operator manifest to bundle directory is empty"
+  file:
+    state: "absent"
+    path: "{{ operator_manifest_to_bundle_dir }}"
+
+- name: "Ensure that the operator manifest to bundle directory is created"
+  file:
+    state: "directory"
+    path: "{{ operator_manifest_to_bundle_dir }}"
+
+- name: "Copy manifest format files to {{ operator_manifest_to_bundle_dir }}"
+  copy:
+    src: "{{ operator_dir }}"
+    dest: "{{ operator_manifest_to_bundle_dir }}"
+    remote_src: yes
+
+- name: "Checking for operator latest version"
+  block:
+    - name: "Find all versions"
+      find:
+        paths: "{{ operator_manifest_to_bundle_dir }}/{{ operator_dir | basename }}"
+        recurse: no
+        file_type: directory
+      register: vd
+  when: operator_version == "latest"
+
+- set_fact:
+    operator_version: "{{ vd.files | sort(attribute='path', reverse=True) | map(attribute='path') | list}}"
+
+- set_fact:
+    operator_name: "{{ operator_dir | basename }}"
+    operator_version: "{{ operator_version[0] | basename }}"
+
+- set_fact:
+    bundle_image: "localhost:5000/operators-test/{{ operator_name }}:v{{ operator_version }}"
+
+- name: Remove bundle image {{ bundle_image }}
+  shell:
+    cmd: "docker rmi -f {{ bundle_image }}"
+
+- name: Generate bundle image {{ bundle_image }}
+  shell:
+    cmd: "{{ opm_bin_path }} alpha bundle build --directory {{ operator_version }} --package {{ operator_name }} -t {{ bundle_image }}"
+    chdir: "{{ operator_manifest_to_bundle_dir }}/{{ operator_name }}"
+
+- name: Push bundle image {{ bundle_image }}
+  shell:
+    cmd: "docker push {{ bundle_image }}"
+
+# - name: Push image {{ bundle_image }}
+#   docker_image:
+#     # Image will be centos:7
+#     name: "localhost:5000/operators-test/{{ operator_name }}"
+#     # Will be pushed to localhost:5000/centos:7
+#     repository: "localhost:5000/operators-test/{{ operator_name }}"
+#     tag: "v{{ operator_version }}"
+#     push: yes
+#     source: local

--- a/roles/extract_operator_bundle/tasks/main.yml
+++ b/roles/extract_operator_bundle/tasks/main.yml
@@ -16,6 +16,13 @@
 - name: "Copy the bundle image layers into a local directory using skopeo"
   shell: "skopeo copy docker://{{ bundle_image }} oci:{{ operator_bundle_dir }}:latest"
   register: skopeo_copy_result
+  when: not run_upstream|bool
+
+- name: "Copy the bundle image layers into a local directory using skopeo"
+  shell: "skopeo copy docker-daemon:{{ bundle_image }} oci:{{ operator_bundle_dir }}:latest"
+  register: skopeo_copy_result
+  when: run_upstream|bool
+
 
 - name: "Inspect the copied image directory"
   shell: "skopeo inspect --raw oci://{{ operator_bundle_dir }}"

--- a/roles/install_operator_prereqs/tasks/main.yml
+++ b/roles/install_operator_prereqs/tasks/main.yml
@@ -121,9 +121,20 @@
       ignore_errors: true
 
     - name: "Install skopeo"
-      package:
-        name: skopeo
-        state: present
+      block:
+        - name: Generating file for install_skopeo.sh
+          template:
+            src: install_skopeo.sh.j2
+            dest: "/tmp/install_skopeo.sh"
+            mode: '0755'
+          when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+
+        - name: "Configuring Kind with registry"
+          shell: "/tmp/install_skopeo.sh"
+          when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+        - package:
+            name: skopeo
+            state: present
       become: true
       when:
         - skopeo_help_result.rc is defined

--- a/roles/install_operator_prereqs/templates/install_skopeo.sh.j2
+++ b/roles/install_operator_prereqs/templates/install_skopeo.sh.j2
@@ -1,0 +1,5 @@
+#!/bin/bash
+. /etc/os-release
+sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/x${NAME}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
+curl -L https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${NAME}_${VERSION_ID}/Release.key  | sudo apt-key add -
+apt-get update -qq

--- a/roles/parse_operator_bundle/tasks/bundle_sanity_checks.yml
+++ b/roles/parse_operator_bundle/tasks/bundle_sanity_checks.yml
@@ -3,12 +3,27 @@
 - name: "Verify ocp versions are valid"
   fail:
     msg: "com.redhat.openshift.versions must only contain v4.5"
-  when: (ocp_versions|length==0) or (ocp_versions|length>1) or ocp_versions[0] != "v4.5"
+  when:
+    - (ocp_versions|length==0) or (ocp_versions|length>1) or ocp_versions[0] != "v4.5"
+    - not run_upstream|bool
 
 - name: "Read the variables from annotations.yaml"
   include_vars:
     file: "{{ operator_work_dir }}/metadata/annotations.yaml"
     name: annotations_vars
+  when: not run_upstream|bool
+
+- name: "Read the variables from annotations.yaml"
+  block:
+    - shell: cat "{{ operator_work_dir }}/metadata/annotations.yaml"
+      register: annotation_data
+    - name: Debug
+      debug:
+        msg: "{{ annotation_data.stdout | from_yaml }}"
+    - name: Set facts
+      set_fact:
+        annotations_vars: "{{ annotation_data.stdout | from_yaml }}"
+  when: run_upstream|bool
 
 - debug:
     var: skopeo_inspect_json.Labels

--- a/roles/parse_operator_bundle/tasks/main.yml
+++ b/roles/parse_operator_bundle/tasks/main.yml
@@ -1,7 +1,15 @@
 ---
 - name: "Inspect the bundle image with skopeo"
-  shell: "skopeo inspect docker://{{ bundle_image }}"
+  # shell: "skopeo inspect docker://{{ bundle_image }}"
+  shell: "skopeo inspect docker-daemon:{{ bundle_image }}"
   register: skopeo_inspect_result
+  when: not run_upstream|bool
+
+- name: "Inspect the bundle image with skopeo"
+  # shell: "skopeo inspect docker://{{ bundle_image }}"
+  shell: "skopeo inspect docker-daemon:{{ bundle_image }}"
+  register: skopeo_inspect_result
+  when: run_upstream|bool
 
 - name: "Save the skopeo inspect output to a log file"
   copy:
@@ -21,7 +29,16 @@
     current_channel: "{{ skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channel.default.v1'] }}" # using default channel since the bundle only has one
     ocp_versions: "{{ skopeo_inspect_json.Labels['com.redhat.openshift.versions'].split(',') }}"
     is_backport: false
+  when: not run_upstream|bool
 
+- set_fact:
+    is_bundle_image: "{{ skopeo_inspect_json.Labels['com.redhat.delivery.operator.bundle'] }}"
+    package_name: "{{ skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.package.v1'] }}"
+    default_channel: "{{ skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channel.default.v1'] }}"
+    current_channel: "{{ skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channel.default.v1'] }}" # using default channel since the bundle only has one
+    ocp_versions: "{{ skopeo_inspect_json.Labels['com.redhat.openshift.versions'].split(',') }}"
+    is_backport: false
+  when: run_upstream|bool
 - set_fact:
     is_backport: "{{ skopeo_inspect_json.Labels['com.redhat.delivery.backport'] }}"
   when: skopeo_inspect_json.Labels['com.redhat.delivery.backport'] is defined

--- a/roles/parse_operator_bundle/tasks/main.yml
+++ b/roles/parse_operator_bundle/tasks/main.yml
@@ -23,22 +23,18 @@
     skopeo_inspect_json: "{{ skopeo_inspect_result.stdout | from_json }}"
 
 - set_fact:
-    is_bundle_image: "{{ skopeo_inspect_json.Labels['com.redhat.delivery.operator.bundle'] }}"
+    is_bundle_image: true
     package_name: "{{ skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.package.v1'] }}"
     default_channel: "{{ skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channel.default.v1'] }}"
     current_channel: "{{ skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channel.default.v1'] }}" # using default channel since the bundle only has one
-    ocp_versions: "{{ skopeo_inspect_json.Labels['com.redhat.openshift.versions'].split(',') }}"
+    ocp_versions: []
     is_backport: false
-  when: not run_upstream|bool
 
 - set_fact:
     is_bundle_image: "{{ skopeo_inspect_json.Labels['com.redhat.delivery.operator.bundle'] }}"
-    package_name: "{{ skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.package.v1'] }}"
-    default_channel: "{{ skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channel.default.v1'] }}"
-    current_channel: "{{ skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channel.default.v1'] }}" # using default channel since the bundle only has one
     ocp_versions: "{{ skopeo_inspect_json.Labels['com.redhat.openshift.versions'].split(',') }}"
-    is_backport: false
-  when: run_upstream|bool
+  when: not run_upstream|bool
+
 - set_fact:
     is_backport: "{{ skopeo_inspect_json.Labels['com.redhat.delivery.backport'] }}"
   when: skopeo_inspect_json.Labels['com.redhat.delivery.backport'] is defined

--- a/roles/validate_operator_bundle/tasks/main.yml
+++ b/roles/validate_operator_bundle/tasks/main.yml
@@ -16,6 +16,13 @@
   shell: "{{ operator_sdk_bin_path }} bundle validate --verbose {{ operator_work_dir }} > {{ work_dir}}/validation-output.txt 2>&1"
   register: sdk_validation_result
   ignore_errors: true
+  when: not run_upstream|bool
+
+- name: "Validate the operator bundle manifest and metadata with operator-sdk bundle validate from image {{ bundle_image }}"
+  shell: "{{ operator_sdk_bin_path }} bundle validate --verbose {{ bundle_image }} > {{ work_dir}}/validation-output.txt 2>&1"
+  register: sdk_validation_result
+  ignore_errors: true
+  when: run_upstream|bool
 
 - name: "Output the return code of operator-sdk bundle validate command to a debug file"
   copy:


### PR DESCRIPTION
First working version.

To install deps use following command or one can put in second command `-e run_prereqs=true`
```
ansible-playbook -vv -i mvala1, local.yml --tags operator_prereqs -e run_upstream=true
```
One can also use `-e run_remove_catalog_repo=false` and previous catalog repo will not be removed. So one can put some mistakes in crds and test it. In this case `git clone` is skipped

To run test bundle
```
ansible-playbook -vv -i mvala1,  local-test-operator-bundle.yml  -e run_upstream=true -e run_prereqs=false -e run_imagesource=false -e operator_dir="/tmp/community-operators-for-catalog/upstream-community-operators/aqua"
```