### PR TITLE
Building of bundle index image working

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -59,7 +59,6 @@
         # run_bundle_test: "{{ run_bundle_test | default(true) }}"
 
   roles:
-    - { role: check-type, tags: ["check_type"] }
     - { role: install_base_packages, tags: ["base"], when: run_host_init|bool }
     - { role: install_docker, tags: ["docker"], when: run_host_init|bool }
     - { role: install_kubectl, tags: ["kubectl"], when: run_host_init|bool }

--- a/roles/build_index_bundle/defaults/main.yml
+++ b/roles/build_index_bundle/defaults/main.yml
@@ -1,8 +1,9 @@
 opm_bin_path: "{{ testing_bin_path }}/opm"
 opm_container_tool: "docker"
 bundle_db: "{{ operator_bundle_dir }}/test-registry.db"
-bundle_index_image_namespace: operatorhub
+bundle_index_image_namespace: test-operator
 bundle_index_registry: localhost:5000
 bundle_image_suffix: "index"
+bundle_index_image: "{{ bundle_index_registry }}/{{ bundle_index_image_namespace }}/{{ operator_name }}-{{ bundle_image_suffix }}:v{{ operator_version }}"
 
 

--- a/roles/build_index_bundle/tasks/main.yml
+++ b/roles/build_index_bundle/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - set_fact:
-  bundle_index_image: "{{ bundle_index_registry }}/{{ bundle_index_image_namespace }}/{{ operator_name }}-{{ bundle_image_suffix }}:v{{ operator_version }}"
+    bundle_index_image: "{{ bundle_index_registry }}/{{ bundle_index_image_namespace }}/{{ operator_name }}-{{ bundle_image_suffix }}:v{{ operator_version }}"
 
 - name: Remove index image {{ bundle_index_image }}
   shell: "{{ opm_container_tool }} rmi -f {{ bundle_index_image }}"


### PR DESCRIPTION
Running test can be done via following command
```
ansible-playbook -vv -i mvala1, local.yml  -e run_upstream=true -e operator_dir=/tmp/community-operators-for-catalog/upstream-community-operators/aqua -e run_prereqs=false --tags bundle_test
```

One can verify index image on host where it was executed by
```
docker pull localhost:5000/test-operator/aqua-index:v1.0.2
```