### PR TITLE
Test on clean machine improved

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -14,11 +14,10 @@
     run_imagesource: true
     run_cleanup: true
     run_remove_catalog_repo: true
-    # run_manifest_test: false
-    # run_bundle_test: true
+    run_manifest_test: false
+    run_bundle_test: true
     distro_type: "{{ 'upstream' if run_upstream else '' }}"
     work_dir: "/tmp/operator-test"
-    # operator_dir: "/tmp/community-operators-for-catalog/upstream-community-operators/aqua" # so operator-courier will be installed
     operator_dir: "dummy" # so operator-courier will be installed
     bundle_image: "dummy" # so skopeo and umoci will be installed
     operator_work_dir: "{{ work_dir }}/operator-files"
@@ -57,29 +56,32 @@
         run_cleanup: "{{ run_cleanup | default(true) }}"
         run_remove_catalog_repo: "{{ run_remove_catalog_repo | default(true) }}"
         operator_format: "bundle"
-        # run_manifest_test: "{{ run_manifest_test | default(false) }}"
-        # run_bundle_test: "{{ run_bundle_test | default(true) }}"
+        run_manifest_test: "{{ run_manifest_test | default(false) }}"
+        run_bundle_test: "{{ run_bundle_test | default(true) }}"
 
   roles:
-    - { role: detect_format, tags: ["always"], when: run_upstream|bool }
     - { role: install_base_packages, tags: ["base"], when: run_host_init|bool }
     - { role: install_docker, tags: ["docker"], when: run_host_init|bool }
     - { role: install_kubectl, tags: ["kubectl"], when: run_host_init|bool }
     - { role: install_kind, tags: ["kind"], when: run_host_init|bool }
-    - { role: install_operator_prereqs, tags: ["operator_prereqs"], when: run_prereqs|bool }
-    - { role: prepare_catalog_repo_upstream, tags: ["always"] }
+    - { role: install_operator_prereqs, when: run_prereqs|bool }
+    - { role: prepare_catalog_repo_upstream, tags: ["always"], when: run_upstream|bool }
+    - { role: detect_format, tags: ["always"], when: run_upstream|bool }
     - { role: build_catalog_upstream, tags: ["operator_catalog"], when: run_catalog_init|bool }
     - { role: build_image_bundle, tags: [never, "operator_manifest_to_bundle"] }
-
-
 
 - name: Running operator manifest test
   import_playbook: local-test-operator.yml
   tags:
     - manifest_test
-  # when: operator_format == "manifest"
+  when:
+    - run_upstream|bool
+    - operator_format == "manifest"
 
 - name: Running operatot bundle test
   import_playbook: local-test-operator-bundle.yml
   tags:
     - bundle_test
+  when:
+    - run_upstream|bool
+    - operator_format == "bundle"

--- a/roles/build_image_bundle/tasks/main.yml
+++ b/roles/build_image_bundle/tasks/main.yml
@@ -44,14 +44,44 @@
 
 - set_fact:
     bundle_image: "{{ bundle_registry }}/{{ bundle_image_namespace }}/{{ operator_name }}:v{{ operator_version }}"
+    annotation_file_path: "{{ operator_manifest_to_bundle_dir }}/{{ operator_name }}/{{ operator_version }}/metadata/annotations.yaml"
 
 - name: Remove bundle image {{ bundle_image }}
   shell: "{{ opm_container_tool }} rmi -f {{ bundle_image }}"
 
-- name: "Generate bundle image {{ bundle_image }} from bundle format"
-  shell:
-    cmd: "{{ opm_bin_path }} alpha bundle build --directory {{ operator_version }} --package {{ operator_name }} -t {{ bundle_image }} -c stable -e stable -b {{ opm_container_tool }}"
-    chdir: "{{ operator_manifest_to_bundle_dir }}/{{ operator_name }}"
+- name: "Read the variables from annotations.yaml"
+  block:
+    - name: Check if annotation file exists
+      stat:
+        path: "{{ annotation_file_path }}"
+      register: annotation_file_st
+
+    - name: Fail if anotation file doesn't exists
+      fail:
+      when: not annotation_file_st.stat.exists
+
+    - name: "Getting content of annotation.yaml file"
+      shell: "cat {{ annotation_file_path }}"
+      register: annotation_data
+
+    - name: Set facts
+      set_fact:
+        annotations_vars: "{{ annotation_data.stdout | from_yaml }}"
+
+    - debug:
+        var: annotations_vars.annotations
+
+    - name: Set annotation variables
+      set_fact:
+        operator_channel_default: "{{ annotations_vars.annotations['operators.operatorframework.io.bundle.channel.default.v1'] }}"
+        operator_channels: "{{ annotations_vars.annotations['operators.operatorframework.io.bundle.channels.v1'] }}"
+        operator_manifest_dir: "{{ annotations_vars.annotations['operators.operatorframework.io.bundle.manifests.v1'] }}"
+        operator_metadata_dir: "{{ annotations_vars.annotations['operators.operatorframework.io.bundle.metadata.v1'] }}"
+        operator_package_name: "{{ annotations_vars.annotations['operators.operatorframework.io.bundle.package.v1'] }}"
+    - name: "Generate bundle image {{ bundle_image }} from bundle format"
+      shell:
+        cmd: "{{ opm_bin_path }} alpha bundle build --directory {{ operator_version }}/{{ operator_manifest_dir }} --package {{ operator_package_name }} -t {{ bundle_image }} -c {{ operator_channels }} -e {{ operator_channel_default }} -b {{ opm_container_tool }}"
+        chdir: "{{ operator_manifest_to_bundle_dir }}/{{ operator_name }}"
   when: operator_format == "bundle"
 
 - name: "Generate bundle image {{ bundle_image }} from manifest format"

--- a/roles/install_operator_prereqs/tasks/main.yml
+++ b/roles/install_operator_prereqs/tasks/main.yml
@@ -14,6 +14,7 @@
     yq_bin_path: "{{ testing_bin_path }}/yq"
     go_bin_path: "{{ testing_bin_path }}/go/bin/go"
     umoci_bin_path: "{{ testing_bin_path }}/umoci"
+    # bundle_image: "{{ 'dummy' if run_upstream else '' }}"
     offline_cataloger_bin_path: "offline-cataloger"
 
 # Install the oc client to talk to any Openshift cluster
@@ -40,7 +41,7 @@
   get_url:
     url: https://github.com/operator-framework/operator-sdk/releases/download/{{ operator_sdk_version }}/operator-sdk-{{ operator_sdk_version }}-x86_64-linux-gnu
     dest: "{{ operator_sdk_bin_path }}"
-    mode: '0755'
+    mode: "0755"
   tags:
     - install
     - host_build
@@ -49,7 +50,7 @@
   get_url:
     url: https://github.com/operator-framework/operator-registry/releases/download/{{ opm_version }}/linux-amd64-opm
     dest: "{{ opm_bin_path }}"
-    mode: '0755'
+    mode: "0755"
   tags:
     - install
     - host_build
@@ -58,7 +59,7 @@
   get_url:
     url: "https://github.com/stedolan/jq/releases/download/jq-{{ jq_version }}/jq-linux64"
     dest: "{{ jq_bin_path }}"
-    mode: '0755'
+    mode: "0755"
   tags:
     - install
     - image_build
@@ -67,7 +68,7 @@
   get_url:
     url: "https://github.com/mikefarah/yq/releases/download/{{ yq_version }}/yq_linux_amd64"
     dest: "{{ yq_bin_path }}"
-    mode: '0755'
+    mode: "0755"
   tags:
     - install
     - image_build
@@ -126,7 +127,7 @@
           template:
             src: install_skopeo.sh.j2
             dest: "/tmp/install_skopeo.sh"
-            mode: '0755'
+            mode: "0755"
           when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
         - name: "Configuring Kind with registry"
@@ -146,7 +147,10 @@
       ignore_errors: true
 
     - name: "Install umoci if not installed"
-      shell: "curl -o {{ umoci_bin_path }} -L https://github.com/openSUSE/umoci/releases/download/{{ umoci_version }}/umoci.amd64 && chmod +x {{ umoci_bin_path }}"
+      get_url:
+        url: "https://github.com/openSUSE/umoci/releases/download/{{ umoci_version }}/umoci.amd64"
+        dest: "{{ umoci_bin_path }}"
+        mode: "0755"
       when:
         - umoci_help_result.rc is defined
         - umoci_help_result.rc != 0


### PR DESCRIPTION
On new host one clone repo
```
git clone https://github.com/operator-framework/community-operators.git /tmp/community-operators-for-catalog
```
Fix replaces in `/tmp/community-operators-for-catalog/scripts/bundle-examples/prometheusoperator/0.32.0/manifests/prometheusoperator.0.32.0.clusterserviceversion.yaml`

and runs 

```
ansible-playbook -vv -i t1, local.yml -e run_upstream=true -e operator_dir=/tmp/community-operators-for-catalog/scripts/bundle-examples/prometheusoperator -e operator_version=0.32.0 -e run_remove_catalog_repo=false -e run_bundle_test=true
```
To run test only one adds `--tags bundle_test`