### PR TITLE
fix fail to get multi-pods running time

### DIFF
--- a/roles/deploy_olm_operator_upstream_bundle/tasks/main.yml
+++ b/roles/deploy_olm_operator_upstream_bundle/tasks/main.yml
@@ -85,7 +85,7 @@
     KUBECONFIG: "{{ kubeconfig_path }}"
 
 - name: "Wait for the operator {{ operator_pod_name }} pod to stay healthy for specific time (upstream only)"
-  shell: "[ $(echo `{{ oc_bin_path }} get pods {{ upstream_namespace_param }}| grep {{ operator_pod_name }} | grep Running| rev | cut -d' ' -f 1 | rev|sed 's/.$//'`) -ge 60 ]"
+  shell: "[ $(echo `{{ oc_bin_path }} get pods {{ upstream_namespace_param }}| grep {{ operator_pod_name }} | grep Running| rev | cut -d' ' -f 1 | rev|sed 's/.$//' | head -1`) -ge 60 ]"
   register: operator_uptime
   retries: "{{ pod_stay_healthy_retries }}"
   delay: "{{ pod_stay_healthy_delay }}"


### PR DESCRIPTION
when the operator controller deployment has multiple replicas, the shell to check pods healthy `$(echo {{ oc_bin_path }} get pods {{ upstream_namespace_param }}| grep {{ operator_pod_name }} | grep Running| rev | cut -d' ' -f 1 | rev|sed 's/.$//' ) -ge 60 `will always fail.